### PR TITLE
Fixed resizing issue in DarkComboBox

### DIFF
--- a/DarkUI/Controls/DarkComboBox.cs
+++ b/DarkUI/Controls/DarkComboBox.cs
@@ -95,6 +95,13 @@ namespace DarkUI.Controls
             PaintCombobox();
         }
 
+        protected override void OnResize(EventArgs e)
+        {
+            base.OnResize(e);
+            _buffer = null;
+            Invalidate();
+        }
+
         private void PaintCombobox()
         {
             if (_buffer == null)


### PR DESCRIPTION
Before this fix, there was white blank space when making the control bigger because the graphics buffer had the original size.
We have to clear the graphics buffer when resizing.