### PR TITLE
Clearing items in a DarkDropDown does not clear the menu

### DIFF
--- a/DarkUI/Collections/ObservableList.cs
+++ b/DarkUI/Collections/ObservableList.cs
@@ -80,6 +80,15 @@ namespace DarkUI.Collections
                 ItemsRemoved(this, new ObservableListModified<T>(new List<T> { item }));
         }
 
+        public new void Clear()
+        {
+            ObservableListModified<T> removed = new ObservableListModified<T>(this.ToList<T>());
+            base.Clear();
+            
+            if (removed.Items.Count() > 0 && ItemsRemoved != null)
+                ItemsRemoved(this, removed);
+        }
+
         #endregion
     }
 }

--- a/DarkUI/Controls/DarkDropdownList.cs
+++ b/DarkUI/Controls/DarkDropdownList.cs
@@ -257,6 +257,12 @@ namespace DarkUI.Controls
                 }
             }
 
+            if (e.Action == NotifyCollectionChangedAction.Reset)
+            {
+                _menu.Items.Clear();
+                SelectedItem = null;
+            }
+
             ResizeMenu();
         }
 

--- a/DarkUI/Controls/DarkTreeView.cs
+++ b/DarkUI/Controls/DarkTreeView.cs
@@ -566,6 +566,8 @@ namespace DarkUI.Controls
             if (IsDragging)
                 return;
 
+            ContentSize = new Size(0, 0);
+
             if (Nodes.Count == 0)
                 return;
 
@@ -573,9 +575,7 @@ namespace DarkUI.Controls
             var isOdd = false;
             var index = 0;
             DarkTreeNode prevNode = null;
-
-            ContentSize = new Size(0, 0);
-
+            
             for (var i = 0; i <= Nodes.Count - 1; i++)
             {
                 var node = Nodes[i];


### PR DESCRIPTION
Fixed an issue where clearing the Items from a DarkDropDown did not also clear the menu.