### PR TITLE
Fixed DarkComboBox disabled text color

### DIFF
--- a/DarkUI/Controls/DarkComboBox.cs
+++ b/DarkUI/Controls/DarkComboBox.cs
@@ -101,6 +101,13 @@ namespace DarkUI.Controls
             _buffer = null;
             Invalidate();
         }
+        
+        protected override void OnEnabledChanged(EventArgs e)
+        {
+            base.OnEnabledChanged(e);
+            _buffer = null;
+            Invalidate();
+        }
 
         private void PaintCombobox()
         {
@@ -110,8 +117,11 @@ namespace DarkUI.Controls
             using (var g = Graphics.FromImage(_buffer))
             {
                 var rect = new Rectangle(0, 0, ClientSize.Width, ClientSize.Height);
+                
+                var textColor = Enabled
+                    ? Colors.LightText
+                    : Colors.DisabledText;
 
-                var textColor = Colors.LightText;
                 var borderColor = Colors.GreySelection;
                 var fillColor = Colors.LightBackground;
 


### PR DESCRIPTION
DarkComboBox had the same look if it was enabled or disabled.
I have fixed that by setting the disabled text color if it is disabled.