### PR TITLE
Fixed the display of the selected item in the combobox when changing its visibility

### DIFF
--- a/DarkUI/Controls/DarkComboBox.cs
+++ b/DarkUI/Controls/DarkComboBox.cs
@@ -89,6 +89,12 @@ namespace DarkUI.Controls
             Invalidate();
         }
 
+        protected override void OnVisibleChanged(EventArgs e)
+        {
+            base.OnVisibleChanged(e);
+            Invalidate();
+        }
+
         protected override void OnInvalidated(InvalidateEventArgs e)
         {
             base.OnInvalidated(e);


### PR DESCRIPTION
I started using DarkUI in my project this week and after implementing it, most of my comboboxes stopped showing the selected item when the group the ComboBox was in became visible.
This pull fix this issue.